### PR TITLE
🐛 [-bug] CI scripts no longer using relative references

### DIFF
--- a/.github/src/workflows/build_and_test..jinja2.yaml
+++ b/.github/src/workflows/build_and_test..jinja2.yaml
@@ -22,4 +22,4 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/src/workflows/exercise_main.jinja2.yaml
+++ b/.github/src/workflows/exercise_main.jinja2.yaml
@@ -45,7 +45,7 @@ jobs:
         configuration:
           - python310
 
-    uses: ./.github/workflows/exercise_main-Impl.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main-Impl.yaml@CI-latest
     with:
       bootstrap_branch_overrides:           ${{ inputs.bootstrap_branch_overrides }}
       repo_name:                            ${{ inputs.repo_name }}

--- a/.github/src/workflows/main.jinja2.yaml
+++ b/.github/src/workflows/main.jinja2.yaml
@@ -20,12 +20,11 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   _a3fa3751-1863-4670-a89c-3e60a602ac0f:
-    name: "[Common_PythonDevelopment]"
-    uses: ./.github/workflows/exercise_main.yaml
+    name: "Common_PythonDevelopment"
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest
     with:
       bootstrap_branch_overrides: "v4-Common_PythonDevelopment:${{ github.ref_name }}"
       repo_name: "davidbrownell/v4-Common_PythonDevelopment"

--- a/.github/src/workflows/on_pr_to_main.jinja2.yaml
+++ b/.github/src/workflows/on_pr_to_main.jinja2.yaml
@@ -24,4 +24,4 @@ on:
 jobs:
   _1fbc5ab1-736c-468f-b711-b825c52d87c8:
     name: "branch: ${{ github.base_ref }}"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/src/workflows/periodic.jinja2.yaml
+++ b/.github/src/workflows/periodic.jinja2.yaml
@@ -24,6 +24,6 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_branch: main_stable

--- a/.github/workflows/build_and_test..yaml
+++ b/.github/workflows/build_and_test..yaml
@@ -39,4 +39,4 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/exercise_main.yaml
+++ b/.github/workflows/exercise_main.yaml
@@ -62,7 +62,7 @@ jobs:
         configuration:
           - python310
 
-    uses: ./.github/workflows/exercise_main-Impl.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main-Impl.yaml@CI-latest
     with:
       bootstrap_branch_overrides:           ${{ inputs.bootstrap_branch_overrides }}
       repo_name:                            ${{ inputs.repo_name }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,12 +37,11 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   _a3fa3751-1863-4670-a89c-3e60a602ac0f:
-    name: "[Common_PythonDevelopment]"
-    uses: ./.github/workflows/exercise_main.yaml
+    name: "Common_PythonDevelopment"
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest
     with:
       bootstrap_branch_overrides: "v4-Common_PythonDevelopment:${{ github.ref_name }}"
       repo_name: "davidbrownell/v4-Common_PythonDevelopment"

--- a/.github/workflows/on_pr_to_main.yaml
+++ b/.github/workflows/on_pr_to_main.yaml
@@ -41,4 +41,4 @@ on:
 jobs:
   _1fbc5ab1-736c-468f-b711-b825c52d87c8:
     name: "branch: ${{ github.base_ref }}"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -41,6 +41,6 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_PythonDevelopment/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_branch: main_stable


### PR DESCRIPTION
Relative references weren't working when the script was invoked from a build associated with a different repo.