### PR TITLE
🐛 [-bug] Ensure that the interface for BuildExeBuildInfo matches

### DIFF
--- a/Libraries/Python/Common_PythonDevelopment/src/Common_PythonDevelopment/BuildExeBuildInfo.py
+++ b/Libraries/Python/Common_PythonDevelopment/src/Common_PythonDevelopment/BuildExeBuildInfo.py
@@ -15,6 +15,7 @@
 # ----------------------------------------------------------------------
 """Contains the BuildExeBuildInfo object"""
 
+import inspect
 import os
 import shutil
 
@@ -38,21 +39,19 @@ class BuildExeBuildInfo(BuildInfoBase):
     # ----------------------------------------------------------------------
     def __init__(
         self,
-        build_name: str,
-        working_dir: Path,
+        name: str,
         required_development_configurations: Optional[list[Pattern]],
         *,
         disable_if_dependency_environment: bool,
     ):
-        if not working_dir.is_dir():
-            raise ValueError("'{}' is not a valid directory.".format(working_dir))
-
+        caller = inspect.getouterframes(inspect.currentframe(), 2)[1]
+        working_dir = PathEx.EnsureDir(Path(caller.filename).parent)
         setup_filename = working_dir / "setup.py"
         if not setup_filename.is_file():
             raise ValueError("'{}' must exist.".format(setup_filename))
 
         super(BuildExeBuildInfo, self).__init__(
-            name=build_name,
+            name=name,
             requires_output_dir=True,
             required_development_configurations=required_development_configurations,
             disable_if_dependency_environment=disable_if_dependency_environment,


### PR DESCRIPTION
Build files that use BuildExeBuildInfo may be invoked in environments that aren't based on Common_PythonDevelopment. In those cases, the build file should be able to seamlessly transition to BuildInfoBase in Common_Foundation.BuildImpl (which will mostly likely display a message saying that the build is not available in this environment configuration).

These changes ensure that the parameters taken in BuildExeBuildInfo's constructor are a subset of those taken in BuildInfoBase's constructor.